### PR TITLE
Update NuScenes mini dataroot handling

### DIFF
--- a/OccWorld/tools/gen_index_nuscenes_mini.py
+++ b/OccWorld/tools/gen_index_nuscenes_mini.py
@@ -5,15 +5,17 @@ from nuscenes.nuscenes import NuScenes
 cams = ["CAM_FRONT_LEFT","CAM_FRONT","CAM_FRONT_RIGHT",
         "CAM_BACK_LEFT","CAM_BACK","CAM_BACK_RIGHT"]
 
-dataroot = "data_mini"
+dataroot = "data/data_mini"
 nusc = NuScenes("v1.0-mini", dataroot=dataroot, verbose=True)
 
-with open("data/index_nuscenes_mini.jsonl","w") as f:
-    for sample in nusc.sample:                     # 遍历 mini 集全部样本
+with open("data/index_nuscenes_mini.jsonl", "w") as f:
+    for sample in nusc.sample:  # 遍历 mini 集全部样本
         scene = nusc.get('scene', sample['scene_token'])['name']
         cams_rel = {
-            cam: os.path.join("data_mini/v1.0-mini",
-                              nusc.get('sample_data', sample['data'][cam])['filename'])
+            cam: os.path.join(
+                dataroot,
+                nusc.get('sample_data', sample['data'][cam])['filename'],
+            )
             for cam in cams
         }
         occ_path = f"occ_gt_npz/{sample['token']}.npz"
@@ -21,6 +23,6 @@ with open("data/index_nuscenes_mini.jsonl","w") as f:
             "scene": scene,
             "sample_token": sample["token"],
             "cams": cams_rel,
-            "occ_gt_npz": occ_path
+            "occ_gt_npz": occ_path,
         }
-        f.write(json.dumps(rec, ensure_ascii=False)+"\n")
+        f.write(json.dumps(rec, ensure_ascii=False) + "\n")


### PR DESCRIPTION
## Summary
- point NuScenes mini dataroot to `data/data_mini`
- build camera sample paths relative to the configured `dataroot`

## Testing
- `python OccWorld/tools/gen_index_nuscenes_mini.py`
- `pytest` *(fails: transformers>=4.41.2,<=4.48.2 is required, found transformers==4.56.1)*

------
https://chatgpt.com/codex/tasks/task_e_68babd4e6540832c8c3afb01523c85b5