### PR TITLE
Update NuScenes mini dataroot handling

### DIFF
--- a/OccWorld/tools/gen_index_nuscenes_mini.py
+++ b/OccWorld/tools/gen_index_nuscenes_mini.py
@@ -1,19 +1,35 @@
 # gen_index_nuscenes_mini.py
 import json, os
+from pathlib import Path
 from nuscenes.nuscenes import NuScenes
 
-cams = ["CAM_FRONT_LEFT","CAM_FRONT","CAM_FRONT_RIGHT",
-        "CAM_BACK_LEFT","CAM_BACK","CAM_BACK_RIGHT"]
+cams = [
+    "CAM_FRONT_LEFT",
+    "CAM_FRONT",
+    "CAM_FRONT_RIGHT",
+    "CAM_BACK_LEFT",
+    "CAM_BACK",
+    "CAM_BACK_RIGHT",
+]
 
-dataroot = "data_mini"
-nusc = NuScenes("v1.0-mini", dataroot=dataroot, verbose=True)
+repo_root = Path(__file__).resolve().parents[2]
+dataroot = repo_root / "data" / "data_mini"
+if not dataroot.exists():
+    raise FileNotFoundError(
+        f"NuScenes mini dataset not found at {dataroot}. "
+        "Please download and extract to this path."
+    )
+nusc = NuScenes("v1.0-mini", dataroot=str(dataroot), verbose=True)
 
-with open("data/index_nuscenes_mini.jsonl","w") as f:
-    for sample in nusc.sample:                     # 遍历 mini 集全部样本
+index_path = repo_root / "data" / "index_nuscenes_mini.jsonl"
+with index_path.open("w") as f:
+    for sample in nusc.sample:  # 遍历 mini 集全部样本
         scene = nusc.get('scene', sample['scene_token'])['name']
         cams_rel = {
-            cam: os.path.join("data_mini/v1.0-mini",
-                              nusc.get('sample_data', sample['data'][cam])['filename'])
+            cam: str(
+                dataroot
+                / nusc.get('sample_data', sample['data'][cam])['filename']
+            )
             for cam in cams
         }
         occ_path = f"occ_gt_npz/{sample['token']}.npz"
@@ -21,6 +37,6 @@ with open("data/index_nuscenes_mini.jsonl","w") as f:
             "scene": scene,
             "sample_token": sample["token"],
             "cams": cams_rel,
-            "occ_gt_npz": occ_path
+            "occ_gt_npz": occ_path,
         }
-        f.write(json.dumps(rec, ensure_ascii=False)+"\n")
+        f.write(json.dumps(rec, ensure_ascii=False) + "\n")


### PR DESCRIPTION
## Summary
- compute NuScenes mini dataroot relative to repo root and validate its existence
- generate camera sample paths using `Path` joins aligned with the dataroot

## Testing
- `python OccWorld/tools/gen_index_nuscenes_mini.py` *(fails: ImportError: libGL.so.1: cannot open shared object file)*
- `pytest` *(fails: 19 errors; see tail for details)*

------
https://chatgpt.com/codex/tasks/task_e_68babd4e6540832c8c3afb01523c85b5