### PR TITLE
Fix NuScenes mini dataroot paths

### DIFF
--- a/OccWorld/tools/gen_index_nuscenes_mini.py
+++ b/OccWorld/tools/gen_index_nuscenes_mini.py
@@ -2,18 +2,32 @@
 import json, os
 from nuscenes.nuscenes import NuScenes
 
-cams = ["CAM_FRONT_LEFT","CAM_FRONT","CAM_FRONT_RIGHT",
-        "CAM_BACK_LEFT","CAM_BACK","CAM_BACK_RIGHT"]
+cams = [
+    "CAM_FRONT_LEFT",
+    "CAM_FRONT",
+    "CAM_FRONT_RIGHT",
+    "CAM_BACK_LEFT",
+    "CAM_BACK",
+    "CAM_BACK_RIGHT",
+]
 
-dataroot = "data_mini"
+dataroot = os.path.join("data", "data_mini")
+if not os.path.exists(dataroot):
+    raise FileNotFoundError(
+        f"NuScenes mini dataset not found at {dataroot}. "
+        "Please download and extract to this path."
+    )
 nusc = NuScenes("v1.0-mini", dataroot=dataroot, verbose=True)
 
-with open("data/index_nuscenes_mini.jsonl","w") as f:
-    for sample in nusc.sample:                     # 遍历 mini 集全部样本
+index_path = os.path.join("data", "index_nuscenes_mini.jsonl")
+with open(index_path, "w") as f:
+    for sample in nusc.sample:  # 遍历 mini 集全部样本
         scene = nusc.get('scene', sample['scene_token'])['name']
         cams_rel = {
-            cam: os.path.join("data_mini/v1.0-mini",
-                              nusc.get('sample_data', sample['data'][cam])['filename'])
+            cam: os.path.join(
+                dataroot,
+                nusc.get('sample_data', sample['data'][cam])['filename'],
+            )
             for cam in cams
         }
         occ_path = f"occ_gt_npz/{sample['token']}.npz"
@@ -21,6 +35,6 @@ with open("data/index_nuscenes_mini.jsonl","w") as f:
             "scene": scene,
             "sample_token": sample["token"],
             "cams": cams_rel,
-            "occ_gt_npz": occ_path
+            "occ_gt_npz": occ_path,
         }
-        f.write(json.dumps(rec, ensure_ascii=False)+"\n")
+        f.write(json.dumps(rec, ensure_ascii=False) + "\n")


### PR DESCRIPTION
## Summary
- Point NuScenes mini dataroot to `data/data_mini`
- Build camera image paths relative to the new dataroot

## Testing
- `python OccWorld/tools/gen_index_nuscenes_mini.py` *(fails: libGL.so.1: cannot open shared object file)*
- `pytest --maxfail=1 -q` *(fails: transformers>=4.41.2,<=4.48.2 is required, found 4.56.1)*

------
https://chatgpt.com/codex/tasks/task_e_68babd4e6540832c8c3afb01523c85b5